### PR TITLE
Print hash in CMutableTransaction::ToString

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -102,7 +102,8 @@ uint256 CMutableTransaction::GetHash() const
 std::string CMutableTransaction::ToString() const
 {
     std::string str;
-    str += strprintf("CMutableTransaction(ver=%d, ",
+    str += strprintf("CMutableTransaction(hash=%s, ver=%d, ",
+        GetHash().ToString().substr(0,10),
         nVersion);
     if (nVersion == 1)
         str += strprintf("nTime=%d, ", nTime);


### PR DESCRIPTION
Keep in line with CTransaction::ToString. Truncates the hash at 10.